### PR TITLE
Add infrastructure for disabling intakes

### DIFF
--- a/src/main/java/frc/team2412/robot/RobotState.java
+++ b/src/main/java/frc/team2412/robot/RobotState.java
@@ -203,8 +203,12 @@ public class RobotState implements Loggable {
 		return m_intakeEnabled;
 	}
 
-	public static void setIntakeEnabled(IntakeEnabled m_intakeEnabled) {
-		RobotState.m_intakeEnabled = m_intakeEnabled;
+	public static void enableIntake() {
+		RobotState.m_intakeEnabled = IntakeEnabled.ENABLED;
+	}
+
+	public static void disableIntake() {
+		RobotState.m_intakeEnabled = IntakeEnabled.DISABLED;
 	}
 
 	public static ClimbState getclimbState() {

--- a/src/main/java/frc/team2412/robot/RobotState.java
+++ b/src/main/java/frc/team2412/robot/RobotState.java
@@ -21,6 +21,9 @@ public class RobotState implements Loggable {
 	public static IntakeDirection m_intakeDirection = IntakeDirection.NONE;
 
 	@Log.ToString(tabName = "Robot State")
+	public static IntakeEnabled m_intakeEnabled = IntakeEnabled.ENABLED;
+
+	@Log.ToString(tabName = "Robot State")
 	public static ClimbState m_climbState = ClimbState.NOT_CLIMBING;
 
 	@Log.ToString(tabName = "Robot State")
@@ -74,13 +77,7 @@ public class RobotState implements Loggable {
 	}
 
 	public static enum IntakeDirection {
-		// Note that both intakes aren't spinning in the DISABLED and NONE
-		// states.
-		// In the DISABLED state, the intakes aren't allowed to spin (typically
-		// to prevent the indexer from jamming) while in the NONE state, the
-		// intakes aren't spinning because the user hasn't made them spin yet.
-		// TODO: Re-examine this logic and simplify it?
-		DISABLED, NONE, FRONT, BACK, BOTH;
+		NONE, FRONT, BACK, BOTH;
 
 		@Override
 		public String toString() {
@@ -90,10 +87,31 @@ public class RobotState implements Loggable {
 				return "Back";
 			} else if (this.equals(BOTH)) {
 				return "Both";
-			} else if (this.equals(DISABLED)) {
-				return "Disabled!";
 			} else {
 				return "None";
+			}
+		}
+	}
+
+	public static enum IntakeEnabled {
+		// Note that this is separated from the IntakeDirection enum. This
+		// allows us to enable/disable the intakes while keeping track of which
+		// intake was last used (this way we don't disrupt the indexer logic,
+		// which relies on this information).
+		// Additionally, IndexBitmapCommand modifies the m_intakeEnabled field
+		// (indirectly, via a setter) while IntakeOnOffSubsystem modifies the
+		// m_intakeDirection field (also indirectly). If we kept the intake
+		// enabled/disabled state information and the intake direction
+		// information in the same enum, both classes would be reading and
+		// writing the same field, which would drastically complicate logic.
+		ENABLED, DISABLED;
+
+		@Override
+		public String toString() {
+			if (this.equals(ENABLED)) {
+				return "Enabled";
+			} else {
+				return "Disabled!";
 			}
 		}
 	}
@@ -179,6 +197,14 @@ public class RobotState implements Loggable {
 
 	public static void setintakeDirection(IntakeDirection m_intakeDirection) {
 		RobotState.m_intakeDirection = m_intakeDirection;
+	}
+
+	public static IntakeEnabled getIntakeEnabled() {
+		return m_intakeEnabled;
+	}
+
+	public static void setIntakeEnabled(IntakeEnabled m_intakeEnabled) {
+		RobotState.m_intakeEnabled = m_intakeEnabled;
 	}
 
 	public static ClimbState getclimbState() {

--- a/src/main/java/frc/team2412/robot/RobotState.java
+++ b/src/main/java/frc/team2412/robot/RobotState.java
@@ -74,7 +74,13 @@ public class RobotState implements Loggable {
 	}
 
 	public static enum IntakeDirection {
-		NONE, FRONT, BACK, BOTH;
+		// Note that both intakes aren't spinning in the DISABLED and NONE
+		// states.
+		// In the DISABLED state, the intakes aren't allowed to spin (typically
+		// to prevent the indexer from jamming) while in the NONE state, the
+		// intakes aren't spinning because the user hasn't made them spin yet.
+		// TODO: Re-examine this logic and simplify it?
+		DISABLED, NONE, FRONT, BACK, BOTH;
 
 		@Override
 		public String toString() {
@@ -84,6 +90,8 @@ public class RobotState implements Loggable {
 				return "Back";
 			} else if (this.equals(BOTH)) {
 				return "Both";
+			} else if (this.equals(DISABLED)) {
+				return "Disabled!";
 			} else {
 				return "None";
 			}

--- a/src/main/java/frc/team2412/robot/commands/indexer/IndexSpitCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/indexer/IndexSpitCommand.java
@@ -21,7 +21,7 @@ public class IndexSpitCommand extends CommandBase {
 		m_indexerMotorSubsystem.getIndexerMotorBackSubsystem().out();
 		m_indexerMotorSubsystem.getIndexerMotorFrontSubsystem().out();
 		m_indexerMotorSubsystem.getIndexerMotorLiftSubsystem().out();
-		m_intakeOnOffSubsystem.setIntake(-1);
+		m_intakeOnOffSubsystem.requestSetIntake(-1);
 	}
 
 	@Override

--- a/src/main/java/frc/team2412/robot/commands/indexer/IndexSpitCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/indexer/IndexSpitCommand.java
@@ -29,7 +29,7 @@ public class IndexSpitCommand extends CommandBase {
 		m_indexerMotorSubsystem.getIndexerMotorBackSubsystem().stop();
 		m_indexerMotorSubsystem.getIndexerMotorFrontSubsystem().stop();
 		m_indexerMotorSubsystem.getIndexerMotorLiftSubsystem().stop();
-		m_intakeOnOffSubsystem.intakeOff();
+		m_intakeOnOffSubsystem.requestIntakeOff();
 	}
 
 	@Override

--- a/src/main/java/frc/team2412/robot/commands/intake/IntakeFrontOffIntakeBackOnCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/intake/IntakeFrontOffIntakeBackOnCommand.java
@@ -14,7 +14,7 @@ public class IntakeFrontOffIntakeBackOnCommand extends CommandBase {
 
 	@Override
 	public void execute() {
-		m_intakeOnOffSubsystem.frontIntakeOffBackIntakeIn();
+		m_intakeOnOffSubsystem.requestFrontIntakeOffBackIntakeIn();
 	}
 
 	@Override

--- a/src/main/java/frc/team2412/robot/commands/intake/IntakeFrontOnIntakeBackOffCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/intake/IntakeFrontOnIntakeBackOffCommand.java
@@ -14,7 +14,7 @@ public class IntakeFrontOnIntakeBackOffCommand extends CommandBase {
 
 	@Override
 	public void execute() {
-		m_intakeOnOffSubsystem.frontIntakeInBackIntakeOff();
+		m_intakeOnOffSubsystem.requestFrontIntakeInBackIntakeOff();
 	}
 
 	@Override

--- a/src/main/java/frc/team2412/robot/commands/intake/IntakeSpitCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/intake/IntakeSpitCommand.java
@@ -14,7 +14,7 @@ public class IntakeSpitCommand extends CommandBase {
 
 	@Override
 	public void execute() {
-		m_intakeMotorOnOffSubsystem.setIntake(-1);
+		m_intakeMotorOnOffSubsystem.requestSetIntake(-1);
 	}
 
 	@Override

--- a/src/main/java/frc/team2412/robot/commands/intake/back/IntakeBackInCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/intake/back/IntakeBackInCommand.java
@@ -20,7 +20,7 @@ public class IntakeBackInCommand extends CommandBase {
 
 	@Override
 	public void execute() {
-		m_intakeOnOffSubsystem.backIntakeIn();
+		m_intakeOnOffSubsystem.requestBackIntakeIn();
 	}
 
 	@Override

--- a/src/main/java/frc/team2412/robot/commands/intake/back/IntakeBackOffCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/intake/back/IntakeBackOffCommand.java
@@ -20,7 +20,7 @@ public class IntakeBackOffCommand extends CommandBase {
 
 	@Override
 	public void execute() {
-		m_intakeOnOffSubsystem.backIntakeOff();
+		m_intakeOnOffSubsystem.requestBackIntakeOff();
 	}
 
 	@Override

--- a/src/main/java/frc/team2412/robot/commands/intake/back/IntakeBackOutCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/intake/back/IntakeBackOutCommand.java
@@ -20,7 +20,7 @@ public class IntakeBackOutCommand extends CommandBase {
 
 	@Override
 	public void execute() {
-		m_intakeOnOffSubsystem.backIntakeOut();
+		m_intakeOnOffSubsystem.requestBackIntakeOut();
 	}
 
 	@Override

--- a/src/main/java/frc/team2412/robot/commands/intake/front/IntakeFrontInCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/intake/front/IntakeFrontInCommand.java
@@ -20,7 +20,7 @@ public class IntakeFrontInCommand extends CommandBase {
 
 	@Override
 	public void execute() {
-		m_intakeMotorOnOffSubsystem.frontIntakeIn();
+		m_intakeMotorOnOffSubsystem.requestFrontIntakeIn();
 	}
 
 	@Override

--- a/src/main/java/frc/team2412/robot/commands/intake/front/IntakeFrontOffCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/intake/front/IntakeFrontOffCommand.java
@@ -20,7 +20,7 @@ public class IntakeFrontOffCommand extends CommandBase {
 
 	@Override
 	public void execute() {
-		m_intakeOnOffSubsystem.frontIntakeOff();
+		m_intakeOnOffSubsystem.requestFrontIntakeOff();
 	}
 
 	@Override

--- a/src/main/java/frc/team2412/robot/commands/intake/front/IntakeFrontOutCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/intake/front/IntakeFrontOutCommand.java
@@ -20,7 +20,7 @@ public class IntakeFrontOutCommand extends CommandBase {
 
 	@Override
 	public void execute() {
-		m_intakeMotorOnOffSubsystem.frontIntakeOut();
+		m_intakeMotorOnOffSubsystem.requestFrontIntakeOut();
 	}
 
 	@Override

--- a/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
@@ -32,59 +32,59 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 		m_intakeFrontMotor.setInverted(true);
 	}
 
-	public void backIntakeOff() {
+	public void requestBackIntakeOff() {
 		m_intakeBackMotor.set(0);
 	}
 
-	public void backIntakeIn() {
+	public void requestBackIntakeIn() {
 		m_intakeBackMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
 		m_lastMotor = IntakeLastMotor.BACK;
 		RobotState.m_intakeDirection = IntakeDirection.BACK;
 	}
 
-	public void backIntakeOut() {
+	public void requestBackIntakeOut() {
 		m_intakeBackMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
 		m_lastMotor = IntakeLastMotor.BACK;
 		RobotState.m_intakeDirection = IntakeDirection.BACK;
 	}
 
-	public void frontIntakeOff() {
+	public void requestFrontIntakeOff() {
 		m_intakeFrontMotor.set(0);
 	}
 
-	public void frontIntakeOffBackIntakeIn() {
+	public void requestFrontIntakeOffBackIntakeIn() {
 		m_intakeFrontMotor.set(0);
 		m_intakeBackMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
 		m_lastMotor = IntakeLastMotor.BACK;
 		RobotState.m_intakeDirection = IntakeDirection.BACK;
 	}
 
-	public void frontIntakeOffBackIntakeOut() {
+	public void requestFrontIntakeOffBackIntakeOut() {
 		m_intakeFrontMotor.set(0);
 		m_intakeBackMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
 		m_lastMotor = IntakeLastMotor.BACK;
 		RobotState.m_intakeDirection = IntakeDirection.BACK;
 	}
 
-	public void frontIntakeIn() {
+	public void requestFrontIntakeIn() {
 		m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
 		m_lastMotor = IntakeLastMotor.FRONT;
 		RobotState.m_intakeDirection = IntakeDirection.FRONT;
 	}
 
-	public void frontIntakeOut() {
+	public void requestFrontIntakeOut() {
 		m_intakeFrontMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
 		m_lastMotor = IntakeLastMotor.FRONT;
 		RobotState.m_intakeDirection = IntakeDirection.FRONT;
 	}
 
-	public void frontIntakeInBackIntakeOff() {
+	public void requestFrontIntakeInBackIntakeOff() {
 		m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
 		m_intakeBackMotor.set(0);
 		m_lastMotor = IntakeLastMotor.FRONT;
 	}
 
-	public void frontIntakeOutBackIntakeOff() {
+	public void requestFrontIntakeOutBackIntakeOff() {
 		m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
 		m_intakeBackMotor.set(0);
 		m_lastMotor = IntakeLastMotor.FRONT;
@@ -94,7 +94,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 		return m_lastMotor;
 	}
 
-	public void intakeOff() {
+	public void requestIntakeOff() {
 		m_intakeMotorGroup.set(0);
 		RobotState.m_intakeDirection = IntakeDirection.NONE;
 	}

--- a/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
@@ -33,61 +33,97 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 
 	public void requestBackIntakeOff() {
+		// We don't need to check if the intakes are disabled here, but we
+		// use the request prefix for consistency (feel free to change this).
 		m_intakeBackMotor.set(0);
 	}
 
 	public void requestBackIntakeIn() {
-		m_intakeBackMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
-		m_lastMotor = IntakeLastMotor.BACK;
-		RobotState.m_intakeDirection = IntakeDirection.BACK;
+		if(!intakesAreDisabled()) {
+			m_intakeBackMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
+			m_lastMotor = IntakeLastMotor.BACK;
+			RobotState.m_intakeDirection = IntakeDirection.BACK;
+		} else {
+			requestIntakeOff();
+		}
 	}
 
 	public void requestBackIntakeOut() {
-		m_intakeBackMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
-		m_lastMotor = IntakeLastMotor.BACK;
-		RobotState.m_intakeDirection = IntakeDirection.BACK;
+		if(!intakesAreDisabled()) {
+			m_intakeBackMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
+			m_lastMotor = IntakeLastMotor.BACK;
+			RobotState.m_intakeDirection = IntakeDirection.BACK;
+		} else {
+			requestIntakeOff();
+		}
 	}
 
 	public void requestFrontIntakeOff() {
+		// We don't need to check if the intakes are disabled here, but we
+		// use the request prefix for consistency (feel free to change this).
 		m_intakeFrontMotor.set(0);
 	}
 
 	public void requestFrontIntakeOffBackIntakeIn() {
-		m_intakeFrontMotor.set(0);
-		m_intakeBackMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
-		m_lastMotor = IntakeLastMotor.BACK;
-		RobotState.m_intakeDirection = IntakeDirection.BACK;
+		if(!intakesAreDisabled()) {
+			m_intakeFrontMotor.set(0);
+			m_intakeBackMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
+			m_lastMotor = IntakeLastMotor.BACK;
+			RobotState.m_intakeDirection = IntakeDirection.BACK;
+		} else {
+			requestIntakeOff();
+		}
 	}
 
 	public void requestFrontIntakeOffBackIntakeOut() {
-		m_intakeFrontMotor.set(0);
-		m_intakeBackMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
-		m_lastMotor = IntakeLastMotor.BACK;
-		RobotState.m_intakeDirection = IntakeDirection.BACK;
+		if(!intakesAreDisabled()) {
+			m_intakeFrontMotor.set(0);
+			m_intakeBackMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
+			m_lastMotor = IntakeLastMotor.BACK;
+			RobotState.m_intakeDirection = IntakeDirection.BACK;
+		} else {
+			requestIntakeOff();
+		}
 	}
 
 	public void requestFrontIntakeIn() {
-		m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
-		m_lastMotor = IntakeLastMotor.FRONT;
-		RobotState.m_intakeDirection = IntakeDirection.FRONT;
+		if(!intakesAreDisabled()) {
+			m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
+			m_lastMotor = IntakeLastMotor.FRONT;
+			RobotState.m_intakeDirection = IntakeDirection.FRONT;
+		} else {
+			requestIntakeOff();
+		}
 	}
 
 	public void requestFrontIntakeOut() {
-		m_intakeFrontMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
-		m_lastMotor = IntakeLastMotor.FRONT;
-		RobotState.m_intakeDirection = IntakeDirection.FRONT;
+		if(!intakesAreDisabled()) {
+			m_intakeFrontMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
+			m_lastMotor = IntakeLastMotor.FRONT;
+			RobotState.m_intakeDirection = IntakeDirection.FRONT;
+		} else {
+			requestIntakeOff();
+		}
 	}
 
 	public void requestFrontIntakeInBackIntakeOff() {
-		m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
-		m_intakeBackMotor.set(0);
-		m_lastMotor = IntakeLastMotor.FRONT;
+		if(!intakesAreDisabled()) {
+			m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
+			m_intakeBackMotor.set(0);
+			m_lastMotor = IntakeLastMotor.FRONT;
+		} else {
+			requestIntakeOff();
+		}
 	}
 
 	public void requestFrontIntakeOutBackIntakeOff() {
-		m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
-		m_intakeBackMotor.set(0);
-		m_lastMotor = IntakeLastMotor.FRONT;
+		if(!intakesAreDisabled()) {
+			m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
+			m_intakeBackMotor.set(0);
+			m_lastMotor = IntakeLastMotor.FRONT;
+		} else {
+			requestIntakeOff();
+		}
 	}
 
 	public IntakeLastMotor getLastMotor() {
@@ -121,5 +157,8 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	public boolean FrontMotorOn() {
 		return (m_intakeFrontMotor.get() != 0);
 	}
-
+	@Log.BooleanBox(colorWhenFalse = "#00FF00", colorWhenTrue = "#FF0000", columnIndex = 2, rowIndex = 0, height = 2, tabName = "Intake")
+	public boolean intakesAreDisabled() {
+		return RobotState.getintakeDirection() == RobotState.IntakeDirection.DISABLED;
+	}
 }

--- a/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
@@ -146,8 +146,12 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 
 	@Config.NumberSlider(min = -1, max = 1, tabName = "Intake")
-	public void setIntake(double speed) {
-		m_intakeMotorGroup.set(speed);
+	public void requestSetIntake(double speed) {
+		if(!intakesAreDisabled()) {
+			m_intakeMotorGroup.set(speed);
+		} else {
+			requestIntakeOff();
+		}
 	}
 
 	public double getCurrentDraw() {

--- a/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
@@ -135,10 +135,14 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 		RobotState.m_intakeDirection = IntakeDirection.NONE;
 	}
 
-	public void intakeIn() {
-		m_intakeMotorGroup.set(1);
-		m_lastMotor = IntakeLastMotor.BOTH;
-		RobotState.m_intakeDirection = IntakeDirection.BOTH;
+	public void requestIntakeIn() {
+		if(!intakesAreDisabled()) {
+			m_intakeMotorGroup.set(1);
+			m_lastMotor = IntakeLastMotor.BOTH;
+			RobotState.m_intakeDirection = IntakeDirection.BOTH;
+		} else {
+			requestIntakeOff();
+		}
 	}
 
 	@Config.NumberSlider(min = -1, max = 1, tabName = "Intake")

--- a/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
@@ -39,7 +39,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 
 	public void requestBackIntakeIn() {
-		if(!intakesAreDisabled()) {
+		if(intakesAreEnabled()) {
 			m_intakeBackMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
 			m_lastMotor = IntakeLastMotor.BACK;
 			RobotState.m_intakeDirection = IntakeDirection.BACK;
@@ -49,7 +49,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 
 	public void requestBackIntakeOut() {
-		if(!intakesAreDisabled()) {
+		if(intakesAreEnabled()) {
 			m_intakeBackMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
 			m_lastMotor = IntakeLastMotor.BACK;
 			RobotState.m_intakeDirection = IntakeDirection.BACK;
@@ -65,7 +65,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 
 	public void requestFrontIntakeOffBackIntakeIn() {
-		if(!intakesAreDisabled()) {
+		if(intakesAreEnabled()) {
 			m_intakeFrontMotor.set(0);
 			m_intakeBackMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
 			m_lastMotor = IntakeLastMotor.BACK;
@@ -76,7 +76,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 
 	public void requestFrontIntakeOffBackIntakeOut() {
-		if(!intakesAreDisabled()) {
+		if(intakesAreEnabled()) {
 			m_intakeFrontMotor.set(0);
 			m_intakeBackMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
 			m_lastMotor = IntakeLastMotor.BACK;
@@ -87,7 +87,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 
 	public void requestFrontIntakeIn() {
-		if(!intakesAreDisabled()) {
+		if(intakesAreEnabled()) {
 			m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
 			m_lastMotor = IntakeLastMotor.FRONT;
 			RobotState.m_intakeDirection = IntakeDirection.FRONT;
@@ -97,7 +97,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 
 	public void requestFrontIntakeOut() {
-		if(!intakesAreDisabled()) {
+		if(intakesAreEnabled()) {
 			m_intakeFrontMotor.set(-IntakeConstants.MAX_INTAKE_SPEED);
 			m_lastMotor = IntakeLastMotor.FRONT;
 			RobotState.m_intakeDirection = IntakeDirection.FRONT;
@@ -107,7 +107,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 
 	public void requestFrontIntakeInBackIntakeOff() {
-		if(!intakesAreDisabled()) {
+		if(intakesAreEnabled()) {
 			m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
 			m_intakeBackMotor.set(0);
 			m_lastMotor = IntakeLastMotor.FRONT;
@@ -117,7 +117,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 
 	public void requestFrontIntakeOutBackIntakeOff() {
-		if(!intakesAreDisabled()) {
+		if(intakesAreEnabled()) {
 			m_intakeFrontMotor.set(IntakeConstants.MAX_INTAKE_SPEED);
 			m_intakeBackMotor.set(0);
 			m_lastMotor = IntakeLastMotor.FRONT;
@@ -136,7 +136,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 
 	public void requestIntakeIn() {
-		if(!intakesAreDisabled()) {
+		if(intakesAreEnabled()) {
 			m_intakeMotorGroup.set(1);
 			m_lastMotor = IntakeLastMotor.BOTH;
 			RobotState.m_intakeDirection = IntakeDirection.BOTH;
@@ -147,7 +147,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 
 	@Config.NumberSlider(min = -1, max = 1, tabName = "Intake")
 	public void requestSetIntake(double speed) {
-		if(!intakesAreDisabled()) {
+		if(intakesAreEnabled()) {
 			m_intakeMotorGroup.set(speed);
 		} else {
 			requestIntakeOff();
@@ -166,7 +166,7 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 		return (m_intakeFrontMotor.get() != 0);
 	}
 	@Log.BooleanBox(colorWhenFalse = "#00FF00", colorWhenTrue = "#FF0000", columnIndex = 2, rowIndex = 0, height = 2, tabName = "Intake")
-	public boolean intakesAreDisabled() {
-		return RobotState.getintakeDirection() == RobotState.IntakeDirection.DISABLED;
+	public boolean intakesAreEnabled() {
+		return RobotState.getIntakeEnabled() == RobotState.IntakeEnabled.DISABLED;
 	}
 }

--- a/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystem.java
@@ -167,6 +167,6 @@ public class IntakeOnOffSubsystem extends SubsystemBase implements Loggable {
 	}
 	@Log.BooleanBox(colorWhenFalse = "#00FF00", colorWhenTrue = "#FF0000", columnIndex = 2, rowIndex = 0, height = 2, tabName = "Intake")
 	public boolean intakesAreEnabled() {
-		return RobotState.getIntakeEnabled() == RobotState.IntakeEnabled.DISABLED;
+		return RobotState.getIntakeEnabled() == RobotState.IntakeEnabled.ENABLED;
 	}
 }

--- a/src/test/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystemTest.java
+++ b/src/test/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystemTest.java
@@ -73,7 +73,7 @@ public class IntakeOnOffSubsystemTest {
 		fakeButton.whenPressed(intakeBackOnCommand);
 
 		// Disable the intakes
-		RobotState.setIntakeEnabled(RobotState.IntakeEnabled.DISABLED);
+		RobotState.disableIntake();
 
 		// Push the button and run the scheduler once
 		fakeButton.push();

--- a/src/test/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystemTest.java
+++ b/src/test/java/frc/team2412/robot/subsystems/IntakeOnOffSubsystemTest.java
@@ -16,6 +16,7 @@ import com.robototes.helpers.MockHardwareExtension;
 import com.robototes.helpers.TestWithScheduler;
 
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.team2412.robot.RobotState;
 import frc.team2412.robot.commands.intake.IntakeFrontOffIntakeBackOnCommand;
 import frc.team2412.robot.commands.intake.IntakeFrontOnIntakeBackOffCommand;
 import frc.team2412.robot.commands.intake.back.IntakeBackOffCommand;
@@ -54,6 +55,37 @@ public class IntakeOnOffSubsystemTest {
 		mockedIntakeBackMotor = mock(CANSparkMax.class);
 
 		realIntakeMotorOnOffSubsystem = new IntakeOnOffSubsystem(mockedIntakeFrontMotor, mockedIntakeBackMotor);
+	}
+
+	@Test
+	public void IntakeDisabledBackOnCommandOnIntakeMotorOnOffSubsystemCallsMotorSet() {
+		// Reset the subsystem to make sure all mock values are reset
+		reset(mockedIntakeFrontMotor);
+		reset(mockedIntakeBackMotor);
+
+		// Create command
+		IntakeBackInCommand intakeBackOnCommand = new IntakeBackInCommand(realIntakeMotorOnOffSubsystem);
+
+		// Create a fake button that will be "pressed"
+		MockButton fakeButton = new MockButton();
+
+		// Tell the button to run example command when pressed
+		fakeButton.whenPressed(intakeBackOnCommand);
+
+		// Disable the intakes
+		RobotState.setIntakeEnabled(RobotState.IntakeEnabled.DISABLED);
+
+		// Push the button and run the scheduler once
+		fakeButton.push();
+		CommandScheduler.getInstance().run();
+		fakeButton.release();
+
+		// Verify that the intake motor wasn't set because intakes are
+		// disabled.
+		verify(mockedIntakeBackMotor, times(0)).set(1);
+
+		// Clear the scheduler
+		TestWithScheduler.schedulerClear();
 	}
 
 	@Ignore


### PR DESCRIPTION
Other commands (including `IndexBitmapCommand`) can now enable and disable the intake via calls to `RobotState.enableIntake()` and `RobotState.disableIntake()`, respectively.

One potential bug is if a command only sets the intake motor speed once, then `RobotState.disableIntake()` is called. This would only disable the intake when another one of `IntakeOnOffSubsystem`'s methods was invoked.